### PR TITLE
Correct Sass names.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,7 @@
+## Migration
+
+### Migrating from v1 to v2
+v1 was released with Sass mixins and functions which do not conform to the Origami specification. v2 was released shortly after the release of v1 to correct these:
+- `oSpaceByName` becomes `oSpacingByName`.
+- `oSpaceByIncrement` becomes `oSpacingByIncrement`.
+- `getBaselineValue` becomes `oSpacingGetBaselineValue`.

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ For compatibility with existing Origami projects, `o-spacing` outputs `px` value
 	$o-spacing-relative-units: true;
 
 	.example {
-		padding: oSpaceByName('s1');  // Small padding (0.24rem).
-		margin-bottom: oSpaceByName('m12'); // Medium margin (3rem).
+		padding: oSpacingByName('s1');  // Small padding (0.24rem).
+		margin-bottom: oSpacingByName('m12'); // Medium margin (3rem).
 	}
 ```
 
@@ -95,28 +95,28 @@ _If using `o-typography` set [$o-typography-relative-units](https://registry.ori
 
 ### Named Space
 
-We recommend Sass users apply space to their project using the `oSpaceByName` function. It accepts a [space name](#named-spaces) and returns a `px` value (or `rem` value, if [relative units](#relative-units) are enabled).
+We recommend Sass users apply space to their project using the `oSpacingByName` function. It accepts a [space name](#named-spaces) and returns a `px` value (or `rem` value, if [relative units](#relative-units) are enabled).
 
 ```scss
 	.example {
-		padding: oSpaceByName('s1');  // Small padding (4px).
-		margin-bottom: oSpaceByName('m12'); // Medium margin (48px).
+		padding: oSpacingByName('s1');  // Small padding (4px).
+		margin-bottom: oSpacingByName('m12'); // Medium margin (48px).
 	}
 ```
 
 ### Baseline Space
 
-We recommend the use of [named spaces](#named-space), but any space that multiplies our [baseline](#baseline) is allowed. To apply a multiple of the baseline value use `oSpaceByIncrement`. It accepts a value to multiply the baseline by and returns a `px` value (or `rem` value, if [relative units](#relative-units) are enabled).
+We recommend the use of [named spaces](#named-space), but any space that multiplies our [baseline](#baseline) is allowed. To apply a multiple of the baseline value use `oSpacingByIncrement`. It accepts a value to multiply the baseline by and returns a `px` value (or `rem` value, if [relative units](#relative-units) are enabled).
 
 ```scss
 	.example {
-		margin-bottom: oSpaceByIncrement('4');
+		margin-bottom: oSpacingByIncrement('4');
 	}
 ```
 
 ### Custom Properties &amp; Utility Classes
 
-We recommend users apply named spaces using the Sass function [oSpaceByName](#named-space), but Sass users may output all `o-spacing` CSS including [utility classes](#markup) and [CSS custom properties](#css-custom-properties) using the `oSpacing` mixin.
+We recommend users apply named spaces using the Sass function [oSpacingByName](#named-space), but Sass users may output all `o-spacing` CSS including [utility classes](#markup) and [CSS custom properties](#css-custom-properties) using the `oSpacing` mixin.
 
 ```scss
 @include oSpacing($opts: (
@@ -124,6 +124,13 @@ We recommend users apply named spaces using the Sass function [oSpaceByName](#na
 	'custom-properties': true // Output CSS variables
 ));
 ```
+
+## Migration
+
+State | Major Version | Last Minor Release | Migration guide |
+:---: | :---: | :---: | :---:
+✨ active | 2 | N/A | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+╳ deprecated | 1 | 1.0 | N/A |
 
 ## Contact
 

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -13,14 +13,14 @@ body {
 }
 
 .demo-named-spaces-container {
-    padding-top: oSpaceByIncrement(3);
-    padding-left: oSpaceByIncrement(3);
+    padding-top: oSpacingByIncrement(3);
+    padding-left: oSpacingByIncrement(3);
     background: repeating-linear-gradient(
         0deg,
         white,
-        white oSpaceByIncrement(1),
-        lightgrey oSpaceByIncrement(1),
-        lightgrey oSpaceByIncrement(2)
+        white oSpacingByIncrement(1),
+        lightgrey oSpacingByIncrement(1),
+        lightgrey oSpacingByIncrement(2)
     );
 }
 
@@ -28,7 +28,7 @@ body {
     position: relative;
     background-color: white;
     border: 1px solid black;
-    padding: 0 oSpaceByIncrement(1);
+    padding: 0 oSpacingByIncrement(1);
     &::before {
         content: '';
         position: absolute;
@@ -43,57 +43,57 @@ body {
     content: '';
     display: inline-block;
     vertical-align: top;
-    margin-bottom: oSpaceByIncrement(5);
+    margin-bottom: oSpacingByIncrement(5);
     background: black;
     background: var(--o-colors-teal, black); // sass-lint:disable-line no-duplicate-properties
 }
 
 .demo-named-space--s1::before {
-    height: oSpaceByName('s1');
-    width: oSpaceByName('s1');
+    height: oSpacingByName('s1');
+    width: oSpacingByName('s1');
 }
 
 .demo-named-space--s2::before {
-    height: oSpaceByName('s2');
-    width: oSpaceByName('s2');
+    height: oSpacingByName('s2');
+    width: oSpacingByName('s2');
 }
 
 .demo-named-space--s3::before {
-    height: oSpaceByName('s3');
-    width: oSpaceByName('s3');
+    height: oSpacingByName('s3');
+    width: oSpacingByName('s3');
 }
 
 .demo-named-space--s4::before {
-    height: oSpaceByName('s4');
-    width: oSpaceByName('s4');
+    height: oSpacingByName('s4');
+    width: oSpacingByName('s4');
 }
 
 .demo-named-space--s6::before {
-    height: oSpaceByName('s6');
-    width: oSpaceByName('s6');
+    height: oSpacingByName('s6');
+    width: oSpacingByName('s6');
 }
 
 .demo-named-space--s8::before {
-    height: oSpaceByName('s8');
-    width: oSpaceByName('s8');
+    height: oSpacingByName('s8');
+    width: oSpacingByName('s8');
 }
 
 .demo-named-space--m12::before {
-    height: oSpaceByName('m12');
-    width: oSpaceByName('m12');
+    height: oSpacingByName('m12');
+    width: oSpacingByName('m12');
 }
 
 .demo-named-space--m16::before {
-    height: oSpaceByName('m16');
-    width: oSpaceByName('m16');
+    height: oSpacingByName('m16');
+    width: oSpacingByName('m16');
 }
 
 .demo-named-space--l18::before {
-    height: oSpaceByName('l18');
-    width: oSpaceByName('l18');
+    height: oSpacingByName('l18');
+    width: oSpacingByName('l18');
 }
 
 .demo-named-space--l24::before {
-    height: oSpaceByName('l24');
-    width: oSpaceByName('l24');
+    height: oSpacingByName('l24');
+    width: oSpacingByName('l24');
 }

--- a/main.scss
+++ b/main.scss
@@ -20,10 +20,10 @@
 		:root {
 			// Named spaces.
 			@each $space-name, $increment in $_o-spacing-sizes {
-				#{--o-spacing-}#{$space-name}: oSpaceByIncrement($increment);
+				#{--o-spacing-}#{$space-name}: oSpacingByIncrement($increment);
 			}
 			// Baseline value.
-			#{--o-spacing-baseline}: getBaselineValue();
+			#{--o-spacing-baseline}: oSpacingGetBaselineValue();
 		}
 	}
 
@@ -31,7 +31,7 @@
 	@if($margin-bottom-utilities) {
 		@each $space-name, $increment in $_o-spacing-sizes {
 			.o-spacing-#{$space-name} {
-				margin-bottom: oSpaceByIncrement($increment);
+				margin-bottom: oSpacingByIncrement($increment);
 			}
 		}
 	}

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,24 +1,24 @@
 /// @param {String} $size-name - Get a recommended space size by name.
 /// @return {Number} - A px value (or rem value if relative units have been enabled).
-@function oSpaceByName($size-name) {
+@function oSpacingByName($size-name) {
     $value: map-get($_o-spacing-sizes, $size-name);
     @if(type-of($value) != 'number') {
         @error 'There is no recommended space named "#{$size-name}". Should be one of #{map-keys($_o-spacing-sizes)}.';
     }
-    @return oSpaceByIncrement($value);
+    @return oSpacingByIncrement($value);
 }
 
 /// @param {Number} $increment - The number to multiply the baseline size by.
 /// @return {Number} - A px value (or rem value if relative units have been enabled).
-@function oSpaceByIncrement($increment) {
+@function oSpacingByIncrement($increment) {
     @if(type-of($increment) != 'number' and floor($increment) != $increment) {
         @error 'Expected a whole number but was given "#{$increment}".';
     }
-    @return $increment * getBaselineValue();
+    @return $increment * oSpacingGetBaselineValue();
 }
 
 /// @return {Number} - A px value representing our spacing baseline (or rem value if relative units have been enabled).
-@function getBaselineValue() {
+@function oSpacingGetBaselineValue() {
     @if($o-spacing-relative-units) {
         @return ($_o-spacing-baseline / 16) * 1rem;
     }

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,14 +1,14 @@
 @include describe('oSpacing mixins') {
 
-	@include describe('oSpaceByName') {
+	@include describe('oSpacingByName') {
 		@include it('returns a px value for a named space') {
 			@include assert-equal(
-				oSpaceByName('s1'),
+				oSpacingByName('s1'),
 				4px
 			);
 
 			@include assert-equal(
-				oSpaceByName('l24'),
+				oSpacingByName('l24'),
 				96px
 			);
 		};
@@ -16,27 +16,27 @@
 		@include it('returns a rem value for a named space when relative units are enabled') {
 			$o-spacing-relative-units: true !global;
 			@include assert-equal(
-				oSpaceByName('s1'),
+				oSpacingByName('s1'),
 				0.25rem
 			);
 
 			@include assert-equal(
-				oSpaceByName('l24'),
+				oSpacingByName('l24'),
 				6rem
 			);
 			$o-spacing-relative-units: false !global;
 		};
 	}
 
-	@include describe('oSpaceByIncrement') {
+	@include describe('oSpacingByIncrement') {
 		@include it('returns a px value based on the baseline') {
 			@include assert-equal(
-				oSpaceByIncrement(1),
+				oSpacingByIncrement(1),
 				4px
 			);
 
 			@include assert-equal(
-				oSpaceByIncrement(100),
+				oSpacingByIncrement(100),
 				400px
 			);
 		};
@@ -44,12 +44,12 @@
 		@include it('returns a rem value based on the baseline when relative units are enabled') {
 			$o-spacing-relative-units: true !global;
 			@include assert-equal(
-				oSpaceByIncrement(1),
+				oSpacingByIncrement(1),
 				0.25rem
 			);
 
 			@include assert-equal(
-				oSpaceByIncrement(100),
+				oSpacingByIncrement(100),
 				25rem
 			);
 			$o-spacing-relative-units: false !global;


### PR DESCRIPTION
this is a major 🤦‍♂ 

v1 was released with Sass mixins and functions which do not conform to the Origami specification:
- `oSpaceByName` becomes `oSpacingByName`.
- `oSpaceByIncrement` becomes `oSpacingByIncrement`.
- `getBaselineValue` becomes `oSpacingGetBaselineValue`.
