### PR TITLE
Fix an error in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ We recommend the use of [named spaces](#named-space), but any space that multipl
 
 ```scss
 	.example {
-		margin-bottom: oSpacingByIncrement('4');
+		margin-bottom: oSpacingByIncrement(4);
 	}
 ```
 


### PR DESCRIPTION
`oSpacingByIncrement` requires a number, and will error if a string is passed in.