### PR TITLE
Add `$o-spacing-names` variable.

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -31,5 +31,6 @@ $_o-spacing-sizes: (
 	'l24': 24,
 );
 
-
-
+/// All space names supported by o-spacing.
+/// @type Map
+$o-spacing-names: map-keys($_o-spacing-sizes);

--- a/test/scss/_variables.test.scss
+++ b/test/scss/_variables.test.scss
@@ -1,0 +1,8 @@
+@include describe('$o-spacing-names') {
+    @include it('includes all space names') {
+        @include assert-equal(
+            $o-spacing-names,
+            ('s1','s2','s3','s4','s6','s8','m12','m16','l18','l24')
+        );
+    }
+}

--- a/test/scss/_variables.test.scss
+++ b/test/scss/_variables.test.scss
@@ -1,8 +1,8 @@
 @include describe('$o-spacing-names') {
-    @include it('includes all space names') {
-        @include assert-equal(
-            $o-spacing-names,
-            ('s1','s2','s3','s4','s6','s8','m12','m16','l18','l24')
-        );
-    }
+	@include it('includes all space names') {
+		@include assert-equal(
+			$o-spacing-names,
+			('s1','s2','s3','s4','s6','s8','m12','m16','l18','l24')
+		);
+	}
 }

--- a/test/scss/index.test.scss
+++ b/test/scss/index.test.scss
@@ -2,3 +2,4 @@
 @import '../../main';
 
 @import 'mixins.test';
+@import 'variables.test';


### PR DESCRIPTION
Allow users to iterate over all space names. This could be
used with `oSpacingByName` to get each space value.

_Note: Space values aren't public outside of function use as
px or relative units may be returned depending on the
`$o-spacing-relative-units` setting._